### PR TITLE
Adds workflow to build and deploy to gh pages

### DIFF
--- a/.github/workflows/publishToGhPagesOnMain.yml
+++ b/.github/workflows/publishToGhPagesOnMain.yml
@@ -15,6 +15,10 @@ jobs:
       uses: actions/setup-dotnet@v1 
       with:
         dotnet-version: 6.0.x 
+        
+    - name: disable AOT compilation
+      run: sed -i 's/<RunAOTCompilation>true/<RunAOTCompilation>false/g' demo/net6.0/v0.1/BlazorStyledTextAreaDemoWasm/Client/BlazorStyledTextAreaDemoWasm.Client.csproj
+  
     - name: Publish with dotnet 
       run: dotnet publish demo/net6.0/v0.1/BlazorStyledTextAreaDemoWasm/Client --configuration Release --output ${{env.PUBLISH_DIR}}
   

--- a/.github/workflows/publishToGhPagesOnMain.yml
+++ b/.github/workflows/publishToGhPagesOnMain.yml
@@ -1,4 +1,4 @@
-name: Publish Packages
+name: Publish demo to gh pages
 
 on:
   push:
@@ -15,7 +15,7 @@ jobs:
       uses: actions/setup-dotnet@v1 
       with:
         dotnet-version: 6.0.x 
-        
+
     - name: disable AOT compilation
       run: sed -i 's/<RunAOTCompilation>true/<RunAOTCompilation>false/g' demo/net6.0/v0.1/BlazorStyledTextAreaDemoWasm/Client/BlazorStyledTextAreaDemoWasm.Client.csproj
   

--- a/.github/workflows/publishToGhPagesOnMain.yml
+++ b/.github/workflows/publishToGhPagesOnMain.yml
@@ -1,0 +1,37 @@
+name: Publish Packages
+
+on:
+  push:
+    branches: [ main ]
+env:
+  PUBLISH_DIR: output 
+  
+jobs:
+  deploy-to-github-pages:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1 
+      with:
+        dotnet-version: 6.0.x 
+    - name: Publish with dotnet 
+      run: dotnet publish demo/net6.0/v0.1/BlazorStyledTextAreaDemoWasm/Client --configuration Release --output ${{env.PUBLISH_DIR}}
+  
+    
+    - name: Change base-tag in index.html from / to BlazorStyledTextArea
+      run: sed -i 's/<base href="\/"[[:blank:]]\/>/<base href="\/BlazorStyledTextArea\/" \/>/g' ${{env.PUBLISH_DIR}}/wwwroot/index.html
+     
+    - name: copy index.html to 404.html
+      run: cp ${{env.PUBLISH_DIR}}/wwwroot/index.html ${{env.PUBLISH_DIR}}/wwwroot/404.html
+      
+    - name: Add .nojekyll file
+      run: touch ${{env.PUBLISH_DIR}}/wwwroot/.nojekyll      
+  
+    - name: Commit wwwroot to GitHub Pages 
+      uses: JamesIves/github-pages-deploy-action@v4.2.5
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        BRANCH: gh-pages
+        FOLDER: ${{env.PUBLISH_DIR}}/wwwroot 
+            


### PR DESCRIPTION
#1  
It works for my fork on https://tesar-tech.github.io/BlazorStyledTextArea/ , it will work for base repo as well.

You just need to set branch for gh pages. `Settings` -> `Pages` -> select `gh-pages` branch (after the build). It will run one additional bot action which will actually deploy the files.

I changed the aot compilation to false (while building the demo, so not in a source code itself). This is mainly for preventing the wasm-tool requirement when using aot compilation...